### PR TITLE
fix: fix header avatar not displaying

### DIFF
--- a/src/views/partials/header.pug
+++ b/src/views/partials/header.pug
@@ -22,6 +22,9 @@ header
                             span
                                 i.fa.fa-user
                         else
-                            img.header__avatar(src="/" + loggedInUser.avatarUrl)
+                            if loggedInUser.socialOnly
+                                img.header__avatar(src=loggedInUser.avatarUrl, crossorigin)
+                            else 
+                                img.header__avatar(src='/' + loggedInUser.avatarUrl, crossorigin)
                 li
                     a(href="/logout") Logout


### PR DESCRIPTION
fix: fix header avatar not displaying
- header avatar image was not displaying properly - the app did not have access to the image source
- fixed path so that image is rendered correctly 